### PR TITLE
fix: correct livecheck and current version info

### DIFF
--- a/Formula/smartthings.rb
+++ b/Formula/smartthings.rb
@@ -4,9 +4,12 @@ class Smartthings < Formula
   url "https://github.com/SmartThingsCommunity/smartthings-cli/releases/download/@smartthings/cli@1.0.0-beta.18/smartthings-macos-x64.tar.gz"
   sha256 "783dd49ff2b1af59a95af3baed9201f01bb37eaa1cf87ce73f86376c45cd3692"
   license "Apache-2.0"
+  version "1.0.0-beta.18"
+  version_scheme 1
 
   livecheck do
-    url :url
+    url :stable
+    regex(/^@smartthings\/cli@(\d+\.\d+\.\d+(-beta\.\d+)?)$/i)
   end
 
   def install


### PR DESCRIPTION
I don't know how well this will play with the github action but we can try and see. This makes running `brew bump smartthingscommunity/smartthings/smartthings` report better version info at least.

# References

(Including these here for potential future reference since Homebrew docs are so hard for me to parse and search.)

* [version_scheme](https://docs.brew.sh/Formula-Cookbook#version-scheme-changes)
* [Git tags livecheck](https://docs.brew.sh/Brew-Livecheck#git-tags)
* [formula version](https://rubydoc.brew.sh/Formula#version%3D-class_method)